### PR TITLE
Add upper range check for decimals param

### DIFF
--- a/irc2_token/sample_token/sample_token.py
+++ b/irc2_token/sample_token/sample_token.py
@@ -63,6 +63,8 @@ class SampleToken(IconScoreBase, TokenStandard):
 
         if _decimals < 0:
             revert("Decimals cannot be less than zero")
+        if _decimals > 21:
+            revert("Decimals cannot be more than 21")
 
         total_supply = _initialSupply * 10 ** _decimals
         Logger.debug(f'on_install: total_supply={total_supply}', TAG)


### PR DESCRIPTION
`decimals` param should not be exceed a certain value to avoid the big number operation.